### PR TITLE
Remove manual docker pull from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
             curl -o- -L https://yarnpkg.com/install.sh | bash
             echo 'export PATH="${PATH}:${HOME}/.yarn/bin"' >> $BASH_ENV
       - run: yarn install
-      - run: docker pull zondax/builder-bolos-emu:latest
       - run: yarn test:unit
 
   publish:


### PR DESCRIPTION
Docker pull should be automatic so we can remove the manual step in CI