### PR TITLE
fix Docker API usage

### DIFF
--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -168,8 +168,10 @@ export default class EmuContainer {
       AttachStderr: true,
       User: '1000',
       Env: environment,
-      PortBindings: portBindings,
-      Binds: dirBindings,
+      HostConfig: {
+        PortBindings: portBindings,
+        Binds: dirBindings,
+      },
       Cmd: [command],
     })
 


### PR DESCRIPTION
According to [Docker API Reference](https://docs.docker.com/engine/api/v1.41/#operation/ContainerCreate) `PortBindings` and `Binds` should be under `HostConfig` node when creating a container.