### PR TITLE
Bind debugger port if required

### DIFF
--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -158,9 +158,13 @@ export default class EmuContainer {
 
     this.log(`[ZEMU] Command: ${command}`)
 
-    const portBindings = {
+    let portBindings: { [index: string]: { HostPort: string }[] } = {
       [`9998/tcp`]: [{ HostPort: options.transportPort }],
       [`5000/tcp`]: [{ HostPort: options.speculosApiPort }],
+    }
+
+    if (customOptions.indexOf('--debug') > -1) {
+      portBindings[`1234/tcp`] = [{ HostPort: '1234' }]
     }
 
     const environment = [


### PR DESCRIPTION
This PR aims to fix #99 by binding the debugger port _only_ if the `--debug` argument is passed to speculos, this is done to avoid breaking parallelized runs, since all containers would try to bind 1234 on the host even when not necessary.

This means that running images in parallel with `--debug` would probably not work, but it should be acceptable and be considered bad usage