### PR TITLE
Update to docker image with latest speculos

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_EMU_IMG = 'zondax/builder-zemu:26758189c883bbdd9c5ee99c83be9253bb521db4'
+export const DEFAULT_EMU_IMG = 'zondax/builder-zemu:be41397067a2f16377f069f0db486b35da88ad3e'
 
 export const TIMEOUT = 1000
 export const DEFAULT_MODEL = 'nanos'


### PR DESCRIPTION
Speculos has been updated to work with the new 2.0.2 SDK for Nano X devices.