### PR TITLE
Remove clicks

### DIFF
--- a/tests/basic.s.test.ts
+++ b/tests/basic.s.test.ts
@@ -160,7 +160,7 @@ test('sign real app', async function () {
 
     const signatureRequest = app.sign(pathAccount, pathChange, pathIndex, txBlob)
     await sim.waitUntilScreenIsNot(sim.getMainMenuSnapshot())
-    await sim.compareSnapshotsAndAccept('.', `s-sign_basic_normal`, 5)
+    await sim.compareSnapshotsAndApprove('.', `s-sign_basic_normal`)
 
     const signatureResponse = await signatureRequest
     console.log(signatureResponse)


### PR DESCRIPTION
this adds two functions to navigate and validate snapshots and do not require the number of required "clicks". 
- **compareSnapshotsAndApprove**: navigates through the snapshots until the Approve event is received then validated them
- **navigateAndCompareUntilText** navigates through the snapshots until a screen containing `text` is found.
The previous functions which require passing the number of clicks were not removed yet.