### PR TITLE
Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc && yarn copy-files",
     "copy-files": "copyfiles -u 0 src/**/*.proto dist/",
-    "test": "yarn build && jest",
+    "test": "yarn build && jest --runInBand",
     "linter": "eslint --ext .ts,.tsx,.js,.jsx --ignore-path .eslintignore . --max-warnings 0",
     "linter:fix": "yarn linter --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\""
@@ -53,7 +53,7 @@
     "@types/sleep": "^0.0.8",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
-    "@zondax/ledger-substrate": "^0.31.0",
+    "@zondax/ledger-substrate": "^0.34.0",
     "copyfiles": "^2.4.1",
     "eslint": "^8.9.0",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "get-port": "^5.1.1",
     "path": "^0.12.7",
     "pngjs": "^6.0.0",
-    "randomstring": "^1.2.1",
-    "sleep": "^6.3.0"
+    "randomstring": "^1.2.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jest": "^26.1.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "jest": "^27.0.6",
+    "jest": "^28.1.3",
     "js-sha512": "^0.8.0",
     "prettier": "^2.5.1",
-    "ts-jest": "^27.0.3",
+    "ts-jest": "^28.0.8",
     "typescript": "^4.5.5"
   },
   "moduleDirectories": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_EMU_IMG = 'zondax/builder-zemu@sha256:cd503798b80f673140f99802404685f87541031ea2124b357a6bfff3d5c79d84'
+export const DEFAULT_EMU_IMG = 'zondax/builder-zemu@sha256:7cae0f781ea6f6a58c39f273763bb61176b377bd0d6c713e59ae38e0531ae4ab'
 
 export const DEFAULT_MODEL = 'nanos'
 export const DEFAULT_START_DELAY = 20000

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,9 @@ export class StartOptions {
   model = 'nanos'
   sdk = ''
   logging = false
+  /**
+  * @deprecated [ZEMU] X11 support is deprecated and not supported anymore
+  */
   X11 = false
   custom = ''
   startDelay = DEFAULT_START_DELAY
@@ -441,6 +444,9 @@ export default class Zemu {
     return true
   }
 
+  /**
+  * @deprecated The method will be deprecated soon. Try to use navigateAndCompareSnapshots instead
+  */
   async compareSnapshotsAndAccept(path: string, testcaseName: string, snapshotCount: number, backClickCount = 0) {
     const instructions = []
     if (snapshotCount > 0) instructions.push(snapshotCount)

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,8 +374,10 @@ export default class Zemu {
     const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
     const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
 
-    fs.ensureDirSync(snapshotPrefixGolden)
-    fs.ensureDirSync(snapshotPrefixTmp)
+    if (takeSnapshots) {
+      fs.ensureDirSync(snapshotPrefixGolden)
+      fs.ensureDirSync(snapshotPrefixTmp)
+    }
 
     let imageIndex = startImgIndex
     let filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
@@ -479,8 +481,10 @@ export default class Zemu {
     const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
     const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
 
-    fs.ensureDirSync(snapshotPrefixGolden)
-    fs.ensureDirSync(snapshotPrefixTmp)
+    if (takeSnapshots) {
+      fs.ensureDirSync(snapshotPrefixGolden)
+      fs.ensureDirSync(snapshotPrefixTmp)
+    }
 
     let imageIndex = startImgIndex
     let filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,11 +416,31 @@ export default class Zemu {
       return imageIndex
   }
 
+  async navigateAndMakeSnapshots(path: string, testcaseName: string, clickSchedule: number[],
+    waitForScreenUpdate = true, startImgIndex = 0) {
+
+      const lastImgIndex = await this.navigate(path, testcaseName, clickSchedule, waitForScreenUpdate, startImgIndex)
+      return this.makeSnapshots(path, testcaseName, lastImgIndex)
+    }
+
   async navigateAndCompareSnapshots(path: string, testcaseName: string, clickSchedule: number[],
                                     waitForScreenUpdate = true, startImgIndex = 0) {
 
     const lastImgIndex = await this.navigate(path, testcaseName, clickSchedule, waitForScreenUpdate, startImgIndex)
     return this.compareSnapshots(path, testcaseName, lastImgIndex)
+  }
+
+  async makeSnapshots(path: string, testcaseName: string, snapshotCount: number): Promise<boolean> {
+    const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
+
+    this.log(`tmp         ${snapshotPrefixTmp}`)
+
+    for (let j = 0; j < snapshotCount + 1; j += 1) {
+      this.log(`Making     ${snapshotPrefixTmp}/${this.formatIndexString(j)}.png`)
+      Zemu.LoadPng2RGB(`${snapshotPrefixTmp}/${this.formatIndexString(j)}.png`)
+    }
+
+    return true
   }
 
   async compareSnapshots(path: string, testcaseName: string, snapshotCount: number): Promise<boolean> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,7 +370,7 @@ export default class Zemu {
 
 
   async navigate(path: string, testcaseName: string, clickSchedule: number[],
-                waitForScreenUpdate = true, startImgIndex = 0) {
+                waitForScreenUpdate = true,  takeSnapshots = true, startImgIndex = 0) {
 
       const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
       const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
@@ -379,7 +379,7 @@ export default class Zemu {
       fs.ensureDirSync(snapshotPrefixTmp)
 
       let imageIndex = startImgIndex
-      let filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
+      const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
       this.log(`---------------------------`)
       this.log(`Start        ${filename}`)
       await this.snapshot(filename)
@@ -389,7 +389,7 @@ export default class Zemu {
         const value = clickSchedule[i]
         if (value == 0) {
           imageIndex += 1
-          filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
+          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
           await this.clickBoth(filename, waitForScreenUpdate)
           continue
         }
@@ -398,7 +398,7 @@ export default class Zemu {
           // Move backwards
           for (let j = 0; j < -value; j += 1) {
             imageIndex += 1
-            filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
+            const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
             await this.clickLeft(filename, waitForScreenUpdate)
           }
           continue
@@ -407,7 +407,7 @@ export default class Zemu {
         // Move forward
         for (let j = 0; j < value; j += 1) {
           imageIndex += 1
-          filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
+          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
           await this.clickRight(filename, waitForScreenUpdate)
         }
       }
@@ -416,31 +416,11 @@ export default class Zemu {
       return imageIndex
   }
 
-  async navigateAndMakeSnapshots(path: string, testcaseName: string, clickSchedule: number[],
-    waitForScreenUpdate = true, startImgIndex = 0) {
-
-      const lastImgIndex = await this.navigate(path, testcaseName, clickSchedule, waitForScreenUpdate, startImgIndex)
-      return this.makeSnapshots(path, testcaseName, lastImgIndex)
-    }
-
   async navigateAndCompareSnapshots(path: string, testcaseName: string, clickSchedule: number[],
                                     waitForScreenUpdate = true, startImgIndex = 0) {
-
-    const lastImgIndex = await this.navigate(path, testcaseName, clickSchedule, waitForScreenUpdate, startImgIndex)
+    const takeSnapshots = true
+    const lastImgIndex = await this.navigate(path, testcaseName, clickSchedule, waitForScreenUpdate, takeSnapshots, startImgIndex)
     return this.compareSnapshots(path, testcaseName, lastImgIndex)
-  }
-
-  async makeSnapshots(path: string, testcaseName: string, snapshotCount: number): Promise<boolean> {
-    const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
-
-    this.log(`tmp         ${snapshotPrefixTmp}`)
-
-    for (let j = 0; j < snapshotCount + 1; j += 1) {
-      this.log(`Making     ${snapshotPrefixTmp}/${this.formatIndexString(j)}.png`)
-      Zemu.LoadPng2RGB(`${snapshotPrefixTmp}/${this.formatIndexString(j)}.png`)
-    }
-
-    return true
   }
 
   async compareSnapshots(path: string, testcaseName: string, snapshotCount: number): Promise<boolean> {
@@ -484,7 +464,7 @@ export default class Zemu {
     return this.navigateAndCompareUntilText(path, testcaseName, 'APPROVE', waitForScreenUpdate, startImgIndex, timeout)
   }
 
-  async navigateUntilText(path: string, testcaseName: string, text: string, waitForScreenUpdate = true,
+  async navigateUntilText(path: string, testcaseName: string, text: string, waitForScreenUpdate = true, takeSnapshots = true,
                           startImgIndex = 0, timeout = 5000): Promise<number> {
       const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
       const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
@@ -493,7 +473,7 @@ export default class Zemu {
       fs.ensureDirSync(snapshotPrefixTmp)
 
       let imageIndex = startImgIndex
-      let filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
+      const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
       await this.snapshot(filename)
 
       let start = new Date()
@@ -514,7 +494,7 @@ export default class Zemu {
 
         if (current_events_qty != events.length) {
           imageIndex += 1
-          filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
+          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
           current_events_qty = events.length
 
           events.forEach((element: any) => {
@@ -534,7 +514,7 @@ export default class Zemu {
           // this case we need to pull again in order to move to next screen
           this.log('No new event, clicking right')
           imageIndex += 1
-          filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
+          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
           await this.clickRight(filename, waitForScreenUpdate)
           start = new Date()
         }
@@ -544,7 +524,8 @@ export default class Zemu {
 
   async navigateAndCompareUntilText(path: string, testcaseName: string, text: string, waitForScreenUpdate = true,
                                     startImgIndex = 0, timeout = 5000): Promise<boolean> {
-    const lastImgIndex = await this.navigateUntilText(path, testcaseName, text, waitForScreenUpdate, startImgIndex, timeout)
+    const takeSnapshots = true
+    const lastImgIndex = await this.navigateUntilText(path, testcaseName, text, waitForScreenUpdate, takeSnapshots, startImgIndex, timeout)
     return this.compareSnapshots(path, testcaseName, lastImgIndex)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -379,7 +379,7 @@ export default class Zemu {
       fs.ensureDirSync(snapshotPrefixTmp)
 
       let imageIndex = startImgIndex
-      const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+      let filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
       this.log(`---------------------------`)
       this.log(`Start        ${filename}`)
       await this.snapshot(filename)
@@ -389,7 +389,7 @@ export default class Zemu {
         const value = clickSchedule[i]
         if (value == 0) {
           imageIndex += 1
-          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+          filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
           await this.clickBoth(filename, waitForScreenUpdate)
           continue
         }
@@ -398,7 +398,7 @@ export default class Zemu {
           // Move backwards
           for (let j = 0; j < -value; j += 1) {
             imageIndex += 1
-            const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+            filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
             await this.clickLeft(filename, waitForScreenUpdate)
           }
           continue
@@ -407,7 +407,7 @@ export default class Zemu {
         // Move forward
         for (let j = 0; j < value; j += 1) {
           imageIndex += 1
-          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+          filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
           await this.clickRight(filename, waitForScreenUpdate)
         }
       }
@@ -473,7 +473,7 @@ export default class Zemu {
       fs.ensureDirSync(snapshotPrefixTmp)
 
       let imageIndex = startImgIndex
-      const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+      let filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
       await this.snapshot(filename)
 
       let start = new Date()
@@ -491,30 +491,23 @@ export default class Zemu {
         }
 
         const events = await this.getEvents()
-
+        imageIndex += 1
+        filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+        
         if (current_events_qty != events.length) {
-          imageIndex += 1
-          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+          
           current_events_qty = events.length
-
           events.forEach((element: any) => {
             if (element['text'].includes(text)) {
               found = true
             }
           })
+        } 
 
-          if (found) {
-            await this.clickBoth(filename, waitForScreenUpdate)
-          } else {
-            // navigate to next screen
-            await this.clickRight(filename, waitForScreenUpdate)
-            start = new Date()
-          }
+        if (found) {
+          await this.clickBoth(filename, waitForScreenUpdate)
         } else {
-          // this case we need to pull again in order to move to next screen
-          this.log('No new event, clicking right')
-          imageIndex += 1
-          const filename = takeSnapshots ? `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png` : undefined
+          // navigate to next screen
           await this.clickRight(filename, waitForScreenUpdate)
           start = new Date()
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -611,6 +611,9 @@ export default class Zemu {
         if (watchdog <= 0) throw 'Timeout waiting for screen update'
         currentScreen = await this.snapshot()
       }
+    } else {
+      // A minimum delay is required
+      await Zemu.delay(100)
     }
     return this.snapshot(filename)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,8 @@ export class StartOptions {
   sdk = ''
   logging = false
   /**
-  * @deprecated [ZEMU] X11 support is deprecated and not supported anymore
-  */
+   * @deprecated [ZEMU] X11 support is deprecated and not supported anymore
+   */
   X11 = false
   custom = ''
   startDelay = DEFAULT_START_DELAY
@@ -348,7 +348,6 @@ export default class Zemu {
 
     this.log(`Wait for screen change`)
 
-
     while (inputSnapshotBufferHex.data.equals(currentSnapshotBufferHex.data)) {
       const currentTime = new Date()
       const elapsed: any = currentTime.getTime() - start.getTime()
@@ -371,50 +370,59 @@ export default class Zemu {
     return takeSnapshots ? `${snapshotPrefix}/${this.formatIndexString(index)}.png` : undefined
   }
 
+  async navigate(
+    path: string,
+    testcaseName: string,
+    clickSchedule: number[],
+    waitForScreenUpdate = true,
+    takeSnapshots = true,
+    startImgIndex = 0,
+  ) {
+    const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
+    const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
 
-  async navigate(path: string, testcaseName: string, clickSchedule: number[],
-                waitForScreenUpdate = true,  takeSnapshots = true, startImgIndex = 0) {
+    fs.ensureDirSync(snapshotPrefixGolden)
+    fs.ensureDirSync(snapshotPrefixTmp)
 
-      const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
-      const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
+    let imageIndex = startImgIndex
+    let filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
+    this.log(`---------------------------`)
+    this.log(`Start        ${filename}`)
+    await this.snapshot(filename)
+    this.log(`Instructions ${clickSchedule}`)
 
-      fs.ensureDirSync(snapshotPrefixGolden)
-      fs.ensureDirSync(snapshotPrefixTmp)
-
-      let imageIndex = startImgIndex
-      let filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
-      this.log(`---------------------------`)
-      this.log(`Start        ${filename}`)
-      await this.snapshot(filename)
-      this.log(`Instructions ${clickSchedule}`)
-
-      for (const value of clickSchedule) {
-        // Both click action
-        if (value == 0) {
-          imageIndex += 1
-          filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
-          await this.clickBoth(filename, waitForScreenUpdate)
-          continue
-        }
-
-        // Move forward/backwards
-        for (let j = 0; j < Math.abs(value); j += 1) {
-          imageIndex += 1
-          filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
-          if (value < 0) {
-            await this.clickLeft(filename, waitForScreenUpdate)
-          } else {
-            await this.clickRight(filename, waitForScreenUpdate)
-          }
-        }
+    for (const value of clickSchedule) {
+      // Both click action
+      if (value == 0) {
+        imageIndex += 1
+        filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
+        await this.clickBoth(filename, waitForScreenUpdate)
+        continue
       }
 
-      await this.dumpEvents()
-      return imageIndex
+      // Move forward/backwards
+      for (let j = 0; j < Math.abs(value); j += 1) {
+        imageIndex += 1
+        filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
+        if (value < 0) {
+          await this.clickLeft(filename, waitForScreenUpdate)
+        } else {
+          await this.clickRight(filename, waitForScreenUpdate)
+        }
+      }
+    }
+
+    await this.dumpEvents()
+    return imageIndex
   }
 
-  async navigateAndCompareSnapshots(path: string, testcaseName: string, clickSchedule: number[],
-                                    waitForScreenUpdate = true, startImgIndex = 0) {
+  async navigateAndCompareSnapshots(
+    path: string,
+    testcaseName: string,
+    clickSchedule: number[],
+    waitForScreenUpdate = true,
+    startImgIndex = 0,
+  ) {
     const takeSnapshots = true
     const lastImgIndex = await this.navigate(path, testcaseName, clickSchedule, waitForScreenUpdate, takeSnapshots, startImgIndex)
     return this.compareSnapshots(path, testcaseName, lastImgIndex)
@@ -443,8 +451,8 @@ export default class Zemu {
   }
 
   /**
-  * @deprecated The method will be deprecated soon. Try to use navigateAndCompareSnapshots instead
-  */
+   * @deprecated The method will be deprecated soon. Try to use navigateAndCompareSnapshots instead
+   */
   async compareSnapshotsAndAccept(path: string, testcaseName: string, snapshotCount: number, backClickCount = 0) {
     const instructions = []
     if (snapshotCount > 0) instructions.push(snapshotCount)
@@ -456,65 +464,82 @@ export default class Zemu {
     return this.navigateAndCompareSnapshots(path, testcaseName, instructions)
   }
 
-  async compareSnapshotsAndApprove(path: string, testcaseName: string, waitForScreenUpdate = true,
-                                   startImgIndex = 0, timeout = 5000): Promise<boolean> {
+  async compareSnapshotsAndApprove(
+    path: string,
+    testcaseName: string,
+    waitForScreenUpdate = true,
+    startImgIndex = 0,
+    timeout = 5000,
+  ): Promise<boolean> {
     return this.navigateAndCompareUntilText(path, testcaseName, 'APPROVE', waitForScreenUpdate, startImgIndex, timeout)
   }
 
-  async navigateUntilText(path: string, testcaseName: string, text: string, waitForScreenUpdate = true, takeSnapshots = true,
-                          startImgIndex = 0, timeout = 5000): Promise<number> {
-      const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
-      const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
+  async navigateUntilText(
+    path: string,
+    testcaseName: string,
+    text: string,
+    waitForScreenUpdate = true,
+    takeSnapshots = true,
+    startImgIndex = 0,
+    timeout = 5000,
+  ): Promise<number> {
+    const snapshotPrefixGolden = Resolve(`${path}/snapshots/${testcaseName}`)
+    const snapshotPrefixTmp = Resolve(`${path}/snapshots-tmp/${testcaseName}`)
 
-      fs.ensureDirSync(snapshotPrefixGolden)
-      fs.ensureDirSync(snapshotPrefixTmp)
+    fs.ensureDirSync(snapshotPrefixGolden)
+    fs.ensureDirSync(snapshotPrefixTmp)
 
-      let imageIndex = startImgIndex
-      let filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
-      await this.snapshot(filename)
+    let imageIndex = startImgIndex
+    let filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
+    await this.snapshot(filename)
 
-      let start = new Date()
-      const prev_events_qty = (await this.getEvents()).length
-      let current_events_qty = prev_events_qty
+    let start = new Date()
+    const prev_events_qty = (await this.getEvents()).length
+    let current_events_qty = prev_events_qty
 
-      let found = false
+    let found = false
 
-      while (!found) {
-        const currentTime = new Date()
-        const elapsed: any = currentTime.getTime() - start.getTime()
+    while (!found) {
+      const currentTime = new Date()
+      const elapsed: any = currentTime.getTime() - start.getTime()
 
-        if (elapsed > timeout) {
-          throw `Timeout waiting for screen containing ${text}`
-        }
+      if (elapsed > timeout) {
+        throw `Timeout waiting for screen containing ${text}`
+      }
 
-        const events = await this.getEvents()
-        imageIndex += 1
-        filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
+      const events = await this.getEvents()
+      imageIndex += 1
+      filename = this.getSnapshotPath(snapshotPrefixTmp, imageIndex, takeSnapshots)
 
-        if (current_events_qty != events.length) {
-
-          current_events_qty = events.length
-          for (const eventEntry of events) {
-            if(eventEntry['text'].includes(text)) {
-              found = true
-              break
-            }
+      if (current_events_qty != events.length) {
+        current_events_qty = events.length
+        for (const eventEntry of events) {
+          if (eventEntry['text'].includes(text)) {
+            found = true
+            break
           }
         }
-
-        if (found) {
-          await this.clickBoth(filename, waitForScreenUpdate)
-        } else {
-          // navigate to next screen
-          await this.clickRight(filename, waitForScreenUpdate)
-          start = currentTime
-        }
       }
-      return imageIndex
+
+      if (found) {
+        await this.clickBoth(filename, waitForScreenUpdate)
+      } else {
+        // navigate to next screen
+        await this.clickRight(filename, waitForScreenUpdate)
+        start = currentTime
+      }
+    }
+    return imageIndex
   }
 
-  async navigateAndCompareUntilText(path: string, testcaseName: string, text: string, waitForScreenUpdate = true,
-                                    startImgIndex = 0, timeout = 5000): Promise<boolean> {
+  async navigateAndCompareUntilText(
+    path: string,
+    testcaseName: string,
+    text: string,
+    waitForScreenUpdate = true,
+    startImgIndex = 0,
+    timeout = 5000,
+  ): Promise<boolean> {
     const takeSnapshots = true
     const lastImgIndex = await this.navigateUntilText(path, testcaseName, text, waitForScreenUpdate, takeSnapshots, startImgIndex, timeout)
     return this.compareSnapshots(path, testcaseName, lastImgIndex)
@@ -567,8 +592,8 @@ export default class Zemu {
   async waitForText(text: any, timeout = 5000, caseSensitive = false) {
     const start = new Date()
     let found = false
-    const flags = !caseSensitive? 'i' : ''
-    const startRegex = new RegExp(text, flags);
+    const flags = !caseSensitive ? 'i' : ''
+    const startRegex = new RegExp(text, flags)
 
     while (!found) {
       const currentTime = new Date()

--- a/src/index.ts
+++ b/src/index.ts
@@ -496,7 +496,7 @@ export default class Zemu {
       let filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
       await this.snapshot(filename)
 
-      const start = new Date()
+      let start = new Date()
       const prev_events_qty = (await this.getEvents()).length
       let current_events_qty = prev_events_qty
 
@@ -528,6 +528,7 @@ export default class Zemu {
           } else {
             // navigate to next screen
             await this.clickRight(filename, waitForScreenUpdate)
+            start = new Date()
           }
         } else {
           // this case we need to pull again in order to move to next screen
@@ -535,6 +536,7 @@ export default class Zemu {
           imageIndex += 1
           filename = `${snapshotPrefixTmp}/${this.formatIndexString(imageIndex)}.png`
           await this.clickRight(filename, waitForScreenUpdate)
+          start = new Date()
         }
       }
       return imageIndex

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,6 +348,7 @@ export default class Zemu {
 
     this.log(`Wait for screen change`)
 
+
     while (inputSnapshotBufferHex.data.equals(currentSnapshotBufferHex.data)) {
       const currentTime = new Date()
       const elapsed: any = currentTime.getTime() - start.getTime()
@@ -569,9 +570,11 @@ export default class Zemu {
     this.log(`Screen changed`)
   }
 
-  async waitForText(text: string, timeout = 5000, caseSensitive = false) {
+  async waitForText(text: any, timeout = 5000, caseSensitive = false) {
     const start = new Date()
     let found = false
+    const flags = !caseSensitive? 'i' : ''
+    const startRegex = new RegExp(text, flags);
 
     while (!found) {
       const currentTime = new Date()
@@ -582,15 +585,8 @@ export default class Zemu {
 
       const events = await this.getEvents()
       events.forEach((element: any) => {
-        let v = element['text']
-        let q = text
-
-        if (!caseSensitive) {
-          v = v.toLowerCase()
-          q = q.toLowerCase()
-        }
-
-        found ||= v.includes(q)
+        const v = element['text']
+        found = startRegex.test(v)
       })
       await Zemu.delay(100)
     }


### PR DESCRIPTION
StartText was replaced by a Regex:
Fix navigate when test has MANY screens

Improve navigation methods: now you can navigate without taking/comparing the snapshots
- new methods **navigate** and **navigateUntilText**
- new flag: waitForScreenUpdate --> waits until the screen is changed / allow comparison when screen must not change
- new flag: startImgIndex --> set first image index. Useful to concatenate several navigations in the same test

https://github.com/Zondax/zemu/issues/142 | https://github.com/Zondax/zemu/issues/81

Add deprecated flags:
https://github.com/Zondax/zemu/issues/79 | https://github.com/Zondax/zemu/issues/130

<!-- ClickUpRef: 2h1bp6f -->
:link: [zboto Link](https://app.clickup.com/t/2h1bp6f)