### PR TITLE
fix: extend hold button delay to 5 seconds

### DIFF
--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -90,7 +90,7 @@ const approveTapButton: IButton = {
 const approveHoldButton: IButton = {
   x: 335,
   y: 525,
-  delay: 4,
+  delay: 5,
 };
 
 const rejectButton: IButton = {


### PR DESCRIPTION
This seems to help run things a bit smoother with the emulator, sometimes it gets stuck at like 90% of the necessary hold.

<!-- ClickUpRef: 861n3bt8q -->
:link: [zboto Link](https://app.clickup.com/t/861n3bt8q)