### PR TITLE
Dynamic tap

### DIFF
--- a/src/Zemu.ts
+++ b/src/Zemu.ts
@@ -712,6 +712,16 @@ export default class Zemu {
     // Approve can be performed with Tap or PressAndHold
     const approveButton = getTouchElement(this.startOptions.model, this.startOptions.approveAction);
 
+    if (this.startOptions.approveAction === ButtonKind.DynamicTapButton) {
+      const events = await this.getEvents();
+      const matchingEvent = events.find((event: IEvent) => textRegex.test(event.text));
+
+      if (matchingEvent != null) {
+        approveButton.x = Math.round(matchingEvent.x + matchingEvent.w / 2);
+        approveButton.y = Math.round(matchingEvent.y + matchingEvent.h / 2);
+      }
+    }
+
     const nav: INavElement = {
       type: touchDevice ? ActionKind.Touch : ActionKind.BothClick,
       button: approveButton,

--- a/src/buttons_flex.ts
+++ b/src/buttons_flex.ts
@@ -171,5 +171,7 @@ export namespace flex {
     [ButtonKind.ConfirmNoButton, flex.confirmNoButton],
     [ButtonKind.ShowQRButton, flex.showQRButton],
     [ButtonKind.CloseQRButton, flex.closeQRButton],
+
+    [ButtonKind.DynamicTapButton, flex.approveTapButton],
   ]);
 }

--- a/src/buttons_stax.ts
+++ b/src/buttons_stax.ts
@@ -170,5 +170,7 @@ export namespace stax {
     [ButtonKind.ConfirmNoButton, stax.confirmNoButton],
     [ButtonKind.ShowQRButton, stax.showQRButton],
     [ButtonKind.CloseQRButton, stax.closeQRButton],
+
+    [ButtonKind.DynamicTapButton, stax.approveTapButton],
   ]);
 }

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -127,7 +127,7 @@ export default class EmuContainer {
     }
 
     const displayEnvironment: string =
-      process.platform === "darwin" ? "host.docker.internal:0" : process.env.DISPLAY ?? "";
+      process.platform === "darwin" ? "host.docker.internal:0" : (process.env.DISPLAY ?? "");
     const environment = [
       `SCP_PRIVKEY='${DEV_CERT_PRIVATE_KEY}'`,
       `BOLOS_SDK='${BOLOS_SDK}'`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,11 +27,13 @@ export interface ISnapshot {
 }
 
 export interface IEvent {
+  text: string;
   x: number;
   y: number;
-  text: string;
+  w: number;
+  h: number;
+  clear: boolean;
 }
-
 export interface ISwipeCoordinates {
   x: number;
   y: number;
@@ -114,4 +116,8 @@ export const enum ButtonKind {
 
   ShowQRButton,
   CloseQRButton,
+
+  // Text to compare must match this button
+  // Zemu will find the center where the text is displayed and tap there
+  DynamicTapButton,
 }

--- a/src/zondax.ts
+++ b/src/zondax.ts
@@ -24,10 +24,10 @@ export function zondaxMainmenuNavigation(model: TModel, clickArray?: number[]): 
   if (isTouchDevice(model)) {
     return new TouchNavigation(model, [
       ButtonKind.InfoButton,
-      ButtonKind.SettingsNavRightButton,
-      ButtonKind.SettingsNavRightButton,
       ButtonKind.ToggleSettingButton1,
       ButtonKind.ToggleSettingButton1,
+      ButtonKind.SettingsNavRightButton,
+      ButtonKind.SettingsNavRightButton,
       ButtonKind.SettingsQuitButton,
     ]);
   }
@@ -39,7 +39,6 @@ export function zondaxToggleExpertMode(model: TModel, clickArray?: number[]): Cl
   if (isTouchDevice(model)) {
     return new TouchNavigation(model, [
       ButtonKind.InfoButton,
-      ButtonKind.NavRightButton,
       ButtonKind.ToggleSettingButton1,
       ButtonKind.SettingsQuitButton,
     ]);


### PR DESCRIPTION
Add `DynamicTapButton` kind. Use approveText / rejectText to let Zemu automatically finds the center of the button and tap on it
Minor changes to adapt to latest UI for Zondax menus