### PR TITLE
Fix enable special mode on touch devices

### DIFF
--- a/src/zondax.ts
+++ b/src/zondax.ts
@@ -50,11 +50,9 @@ export function zondaxToggleExpertMode(model: TModel, clickArray?: number[]): Cl
 export function zondaxTouchEnableSpecialMode(model: TModel, toggleSettingButton?: ButtonKind): TouchNavigation {
   return new TouchNavigation(model, [
     ButtonKind.InfoButton,
-    ButtonKind.SettingsNavRightButton,
-    ButtonKind.SettingsNavRightButton,
     ButtonKind.ToggleSettingButton1,
-    ButtonKind.SettingsNavLeftButton,
     ButtonKind.SettingsNavRightButton,
+    ButtonKind.SettingsNavLeftButton,
     toggleSettingButton ?? ButtonKind.ToggleSettingButton2,
     ButtonKind.SwipeContinueButton,
     ButtonKind.ConfirmYesButton,


### PR DESCRIPTION
Since touch device screens are static, we need to refresh the screen once expert mode is enabled so that we can see the rest of fields.
To refresh the screen we can navigate right and then back left. We can't do left and then right because when on expert mode screen, there is nothing to the left, so zemu remains in deadlock waiting for a screen change.
This change fixes crowdloans.