### PR TITLE
Track already searched events

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,16 @@ export interface IEvent {
   h: number;
   clear: boolean;
 }
+
+export function areEventsEqual(event1: IEvent, event2: IEvent): boolean {
+  return event1.text === event2.text &&
+         event1.x === event2.x &&
+         event1.y === event2.y &&
+         event1.w === event2.w &&
+         event1.h === event2.h &&
+         event1.clear === event2.clear;
+}
+
 export interface ISwipeCoordinates {
   x: number;
   y: number;


### PR DESCRIPTION
When calling `getEvents`, a blob with the information of all the snapshots is returned, something like the following :

```
[{"text":"Algorand","x":160,"y":236,"w":159,"h":40,"clear":false},{"text":"This application enables","x":80,"y":294,"w":320,"h":32,"clear":false},{"text":"signing transactions on the","x":61,"y":330,"w":357,"h":32,"clear":false},{"text":"Algorand network","x":123,"y":366,"w":234,"h":32,"clear":false},{"text":"Quit app","x":183,"y":538,"w":114,"h":32,"clear":false},{"text":"Review Group ","x":122,"y":218,"w":248,"h":40,"clear":false},{"text":"Transaction","x":138,"y":258,"w":202,"h":40,"clear":false},{"text":"Transactions to review: 3","x":72,"y":316,"w":334,"h":32,"clear":false},{"text":"Swipe to review","x":135,"y":376,"w":210,"h":32,"clear":false}.......
```

Up until now, this served its purpose when looking for an Approve keyword such as "Hold To Sign", since we only expect one approve keyword per transaction.

For Algorand's transaction Group though, multiple transactions are processed in batch, meaning there are multiple "Hold To Sign" screens. This means that we need to distinguish between the snapshots we have already visited and the ones we have not.

This PR tracks adds tracking for the events that have already been searched, so that only one iteration per event takes place.



<!-- ClickUpRef: 8697yt3mt -->
:link: [zboto Link](https://app.clickup.com/t/8697yt3mt)