### PR TITLE
fix: Zemu.checkAndPullImage should reliably reject

### DIFF
--- a/tests/check-and-pull-image.test.ts
+++ b/tests/check-and-pull-image.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from 'vitest'
+import EmuContainer from '../src/emulator'
+import Zemu from '../src/Zemu'
+import { DEFAULT_EMU_IMG } from '../src/constants'
+
+describe('checkAndPullImage', () => {
+  test('EmuContainer should throw if checking for image fails', async () => {
+    await expect(() => EmuContainer.checkAndPullImage('please fail')).rejects.toThrow()
+  })
+
+  test('Zemu should throw if checking for image fails', async () => {
+    vi.spyOn(EmuContainer, 'checkAndPullImage').mockImplementationOnce(async (discarded) => {
+      // expect a typical call
+      expect(discarded).toBe(DEFAULT_EMU_IMG)
+      // forward to the original implementation
+      return EmuContainer.checkAndPullImage('please fail')
+    })
+
+    await expect(() => Zemu.checkAndPullImage()).rejects.toThrow()
+  })
+})

--- a/tests/check-and-pull-image.test.ts
+++ b/tests/check-and-pull-image.test.ts
@@ -3,9 +3,11 @@ import EmuContainer from '../src/emulator'
 import Zemu from '../src/Zemu'
 import { DEFAULT_EMU_IMG } from '../src/constants'
 
-describe('checkAndPullImage', () => {
+describe('checkAndPullImage fails', () => {
+  const BAD_IMAGE_NAME = 'this is not a valid image name'
+
   test('EmuContainer should throw if checking for image fails', async () => {
-    await expect(() => EmuContainer.checkAndPullImage('please fail')).rejects.toThrow()
+    await expect(() => EmuContainer.checkAndPullImage(BAD_IMAGE_NAME)).rejects.toThrow()
   })
 
   test('Zemu should throw if checking for image fails', async () => {
@@ -13,7 +15,7 @@ describe('checkAndPullImage', () => {
       // expect a typical call
       expect(discarded).toBe(DEFAULT_EMU_IMG)
       // forward to the original implementation
-      return EmuContainer.checkAndPullImage('please fail')
+      return EmuContainer.checkAndPullImage(BAD_IMAGE_NAME)
     })
 
     await expect(() => Zemu.checkAndPullImage()).rejects.toThrow()


### PR DESCRIPTION
if the network request made by `checkAndPullImage` fails for any reason, sometimes the promise stalls forever.

this PR attempts to make promise rejection more reliable.

relevant to https://github.com/Zondax/zemu/issues/564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during image pulling to ensure errors are properly reported and prevent potential runtime issues.

* **Tests**
  * Added new tests to verify correct error handling when pulling invalid images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->