### PR TITLE
Pin pnpm to 10.x in mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "22"
-pnpm = "latest"
+pnpm = "10"
 bun = "latest"
 
 [env]


### PR DESCRIPTION
pnpm v11.0.0 changed release asset naming from `pnpm-linux-x64` (raw binary) to `pnpm-linux-x64.tar.gz` (tarball). Aqua's pnpm metadata still expects the old name, so `latest` now fails to install in CI. Pin to the 10.x series until aqua updates.