### PR TITLE
ci: bump _workflows to v6 and pin node to 22.22.1

### DIFF
--- a/.github/workflows/ci-ts.yaml
+++ b/.github/workflows/ci-ts.yaml
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   ts-checks:
-    uses: zondax/_workflows/.github/workflows/_checks-ts.yaml@v5
+    uses: zondax/_workflows/.github/workflows/_checks-ts.yaml@v6
     with:
       package_manager: pnpm
-      node_version: "22"
+      node_version: "22.22.1"
       enable_tests: false  # Disable tests here since they need Docker
       enable_coverage: false
       test_command: "test"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   publish-npm:
-    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v5
+    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v6
     permissions:
       contents: read
       id-token: write # Required for OIDC trusted publishing - must be in caller!
@@ -22,4 +22,5 @@ jobs:
       timeout_minutes: 15
       dry_run: false
       github_app_auth: false
+      node_version: "22.22.1"
 


### PR DESCRIPTION
## Summary

The `Publish NPM Package` workflow [fails](https://github.com/Zondax/zemu/actions/runs/25117389202) at the `npm install -g npm@latest` step inside `_publish-npm.yaml` with:

```
npm error Cannot find module 'promise-retry'
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```
