### PR TITLE
fix(touch): guard DynamicTapButton against zero-coord events)

### DIFF
--- a/src/Zemu.ts
+++ b/src/Zemu.ts
@@ -985,7 +985,9 @@ export default class Zemu {
       const events = await this.getEvents()
       const matchingEvent = events.find((event: IEvent) => textRegex.test(event.text))
 
-      if (matchingEvent != null) {
+      // Only override default coords when the event has a real bounding box;
+      // some speculos versions report text-only events with x=y=w=h=0.
+      if (matchingEvent != null && matchingEvent.w > 0 && matchingEvent.h > 0) {
         approveButton.x = Math.round(matchingEvent.x + matchingEvent.w / 2)
         approveButton.y = Math.round(matchingEvent.y + matchingEvent.h / 2)
       }


### PR DESCRIPTION
## Summary                                                                                                              
  When `approveAction` is `DynamicTapButton`, `navigateUntilText` overrides the default approve button coordinates with the center of the bounding box of the event whose text matches `approveKeyword`. Some speculos versions emit text-only events with `x=y=w=h=0`, which caused the touch action to land at `(0, 0)` (top-left corner) instead of the actual button.                                                                

  ## Fix                                                                                                                  
  Only override the default `approveButton` coordinates when the matched event has a real bounding box (`w > 0 && h > 0`). Otherwise, keep the static coordinates returned by `getTouchElement(model, DynamicTapButton)`, which are  the correct location of the Confirm button for that model.  